### PR TITLE
feat: add highlighting for scopes

### DIFF
--- a/views.sublime-syntax
+++ b/views.sublime-syntax
@@ -16,16 +16,12 @@ contexts:
     # comment
     - match: "^#.+$"
       scope: comment.views
-    
-    # margin
-    - match: "^margin[a-zA-Z]*\\s*(.+)$"
-      captures:
-        1: constant.numeric.margin.views
 
-    # padding
-    - match: "^padding[a-zA-Z]*\\s*(.+)$"
+    # scope
+    - match: "^(when|onWhen)[a-zA-Z]*\\s*(.+)$"
       captures:
-        1: constant.numeric.padding.views
+        1: scope.views
+        2: variable.function.code.views
 
     # code
     - match: "^[a-z][a-zA-Z0-9]*\\s*"

--- a/views.sublime-syntax
+++ b/views.sublime-syntax
@@ -17,11 +17,13 @@ contexts:
     - match: "^#.+$"
       scope: comment.views
 
-    # scope
-    - match: "^(when|onWhen)[a-zA-Z]*\\s*(.+)$"
-      captures:
-        1: scope.views
-        2: variable.function.code.views
+    # when
+    - match: "^when.+$"
+      scope: variable.function.code.views
+
+    # onWhen
+    - match: "^onWhen.+$"
+      scope: onWhen.views
 
     # code
     - match: "^[a-z][a-zA-Z0-9]*\\s*"

--- a/views.tmTheme
+++ b/views.tmTheme
@@ -42,6 +42,17 @@
 		</dict>
 		<dict>
 			<key>name</key>
+			<string>Scope</string>
+			<key>scope</key>
+			<string>scope</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#FEF45C</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
 			<string>String</string>
 			<key>scope</key>
 			<string>string.value.views</string>

--- a/views.tmTheme
+++ b/views.tmTheme
@@ -42,13 +42,13 @@
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>Scope</string>
+			<string>onWhen</string>
 			<key>scope</key>
-			<string>scope</string>
+			<string>onWhen</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#FEF45C</string>
+				<string>#A2E1F9</string>
 			</dict>
 		</dict>
 		<dict>
@@ -60,28 +60,6 @@
 			<dict>
 				<key>foreground</key>
 				<string>#1FCC69</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>name</key>
-			<string>Margin</string>
-			<key>scope</key>
-			<string>constant.numeric.margin.views</string>
-			<key>settings</key>
-			<dict>
-				<key>foreground</key>
-				<string>#8F4BF2</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>name</key>
-			<string>Padding</string>
-			<key>scope</key>
-			<string>constant.numeric.padding.views</string>
-			<key>settings</key>
-			<dict>
-				<key>foreground</key>
-				<string>#ffce00</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Looks like this:

![screen shot 2018-01-28 at 8 52 51 pm](https://user-images.githubusercontent.com/1708243/35486942-96884bc6-046d-11e8-8412-30c451fb854e.png)

Applies to both `when` and `onWhen`. Is that alright, or do we want to treat them differently?